### PR TITLE
Fixed BinaryMessenger Nullability, issue #11

### DIFF
--- a/android/src/main/kotlin/com/sharmadhiraj/installed_apps/InstalledAppsPlugin.kt
+++ b/android/src/main/kotlin/com/sharmadhiraj/installed_apps/InstalledAppsPlugin.kt
@@ -35,7 +35,7 @@ class InstalledAppsPlugin() : MethodCallHandler, FlutterPlugin, ActivityAware {
         }
 
         @JvmStatic
-        fun register(messenger: BinaryMessenger?) {
+        fun register(messenger: BinaryMessenger) {
             val channel = MethodChannel(messenger, "installed_apps")
             channel.setMethodCallHandler(InstalledAppsPlugin())
         }


### PR DESCRIPTION
# Error in issue #11 
```
Launching lib\main.dart on Redmi Note 5 Pro in debug mode...
Parameter format not correct -
e: C:\src\flutter\.pub-cache\hosted\pub.dartlang.org\installed_apps-1.3.0\android\src\main\kotlin\com\sharmadhiraj\installed_apps\InstalledAppsPlugin.kt: (39, 41):
Type mismatch: inferred type is BinaryMessenger? but BinaryMessenger was expected

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':installed_apps:compileDebugKotlin'.
> Compilation error. See log for more details

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
* Get more help at https://help.gradle.org
BUILD FAILED in 22s
Exception: Gradle task assembleDebug failed with exit code 1
Exited (sigterm)

```