### PR TITLE
Improve getAppInfo Method: Return Null for Uninstalled Apps

### DIFF
--- a/example/lib/screens/app_info.dart
+++ b/example/lib/screens/app_info.dart
@@ -20,9 +20,9 @@ class AppInfoScreen extends StatelessWidget {
   }
 
   Widget _buildAppInfoWithPackageName() {
-    return FutureBuilder<AppInfo>(
+    return FutureBuilder<AppInfo?>(
       future: InstalledApps.getAppInfo("com.google.android.gm"),
-      builder: (BuildContext buildContext, AsyncSnapshot<AppInfo> snapshot) {
+      builder: (BuildContext buildContext, AsyncSnapshot<AppInfo?> snapshot) {
         return snapshot.connectionState == ConnectionState.done
             ? snapshot.hasData && snapshot.data != null
                 ? _buildAppInfo(snapshot.data!)

--- a/lib/installed_apps.dart
+++ b/lib/installed_apps.dart
@@ -69,13 +69,14 @@ class InstalledApps {
   /// [packageName] is the package name of the app to retrieve information for.
   ///
   /// Returns an [AppInfo] object representing the app.
-  static Future<AppInfo> getAppInfo(String packageName) async {
+  /// If app is not found it returns null
+  static Future<AppInfo?> getAppInfo(String packageName) async {
     var app = await _channel.invokeMethod(
       "getAppInfo",
       {"package_name": packageName},
     );
     if (app == null) {
-      throw ("App not found with provided package name $packageName");
+      return null;
     } else {
       return AppInfo.create(app);
     }


### PR DESCRIPTION
**Problem:** When using the `getAppInfo` method, the method throws an exception if the application is not installed, instead of returning a value that can be handled programmatically.

**Solution:** For my specific use case, I modified the `getAppInfo` method to return `null` when the application is not found, instead of throwing an exception. This allows for more graceful handling of scenarios where the application is not installed, without disrupting the flow of the application with an unhandled exception.
