### PR TITLE
Bug Fix: IllegalArgumentException in drawableToBitmap function and Additional Enhancements

### DIFF
--- a/android/src/main/kotlin/com/sharmadhiraj/installed_apps/DrawableUtil.kt
+++ b/android/src/main/kotlin/com/sharmadhiraj/installed_apps/DrawableUtil.kt
@@ -18,14 +18,12 @@ class DrawableUtil {
         }
 
         private fun drawableToBitmap(drawable: Drawable): Bitmap {
-            if (drawable is BitmapDrawable) {
+            if (drawable is BitmapDrawable && drawable.bitmap != null) {
                 return drawable.bitmap
             }
-            val bitmap = Bitmap.createBitmap(
-                drawable.intrinsicWidth,
-                drawable.intrinsicHeight,
-                Bitmap.Config.ARGB_8888
-            )
+            val width = if (drawable.intrinsicWidth > 0) drawable.intrinsicWidth else 1
+            val height = if (drawable.intrinsicHeight > 0) drawable.intrinsicHeight else 1
+            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
             val canvas = Canvas(bitmap)
             drawable.setBounds(0, 0, canvas.width, canvas.height)
             drawable.draw(canvas)

--- a/android/src/main/kotlin/com/sharmadhiraj/installed_apps/InstalledAppsPlugin.kt
+++ b/android/src/main/kotlin/com/sharmadhiraj/installed_apps/InstalledAppsPlugin.kt
@@ -71,9 +71,16 @@ class InstalledAppsPlugin() : MethodCallHandler, FlutterPlugin, ActivityAware {
                 val includeSystemApps = call.argument("exclude_system_apps") ?: true
                 val withIcon = call.argument("with_icon") ?: false
                 val packageNamePrefix: String = call.argument("package_name_prefix") ?: ""
+                val onlyAppsWithLaunchIntent: Boolean =
+                    call.argument("only_apps_with_launch_intent") ?: true
                 Thread {
                     val apps: List<Map<String, Any?>> =
-                        getInstalledApps(includeSystemApps, withIcon, packageNamePrefix)
+                        getInstalledApps(
+                            includeSystemApps,
+                            withIcon,
+                            packageNamePrefix,
+                            onlyAppsWithLaunchIntent
+                        )
                     result.success(apps)
                 }.start()
             }
@@ -121,21 +128,35 @@ class InstalledAppsPlugin() : MethodCallHandler, FlutterPlugin, ActivityAware {
     private fun getInstalledApps(
         excludeSystemApps: Boolean,
         withIcon: Boolean,
-        packageNamePrefix: String
+        packageNamePrefix: String,
+        onlyAppsWithLaunchIntent: Boolean,
     ): List<Map<String, Any?>> {
-        val packageManager = getPackageManager(context!!)
+        val packageManager = context!!.packageManager
         var installedApps = packageManager.getInstalledApplications(0)
-        if (excludeSystemApps)
-            installedApps =
-                installedApps.filter { app -> !isSystemApp(packageManager, app.packageName) }
-        if (packageNamePrefix.isNotEmpty())
+
+        if (excludeSystemApps) {
             installedApps = installedApps.filter { app ->
-                app.packageName.startsWith(
-                    packageNamePrefix.lowercase(ENGLISH)
-                )
+                !isSystemApp(packageManager, app.packageName)
             }
-        return installedApps.map { app -> convertAppToMap(packageManager, app, withIcon) }
+        }
+
+        if (packageNamePrefix.isNotEmpty()) {
+            installedApps = installedApps.filter { app ->
+                app.packageName.startsWith(packageNamePrefix.lowercase(Locale.ENGLISH))
+            }
+        }
+
+        if (onlyAppsWithLaunchIntent) {
+            installedApps = installedApps.filter { app ->
+                packageManager.getLaunchIntentForPackage(app.packageName) != null
+            }
+        }
+
+        return installedApps.map { app ->
+            convertAppToMap(packageManager, app, withIcon)
+        }
     }
+
 
     private fun startApp(packageName: String?): Boolean {
         if (packageName.isNullOrBlank()) return false

--- a/android/src/main/kotlin/com/sharmadhiraj/installed_apps/InstalledAppsPlugin.kt
+++ b/android/src/main/kotlin/com/sharmadhiraj/installed_apps/InstalledAppsPlugin.kt
@@ -20,7 +20,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.PluginRegistry.Registrar
-import java.util.Locale.ENGLISH
+import java.util.Locale
 
 
 class InstalledAppsPlugin() : MethodCallHandler, FlutterPlugin, ActivityAware {

--- a/android/src/main/kotlin/com/sharmadhiraj/installed_apps/Util.kt
+++ b/android/src/main/kotlin/com/sharmadhiraj/installed_apps/Util.kt
@@ -28,7 +28,18 @@ class Util {
             map["version_code"] = getVersionCode(packageInfo)
             map["built_with"] = BuiltWithUtil.getPlatform(packageInfo.applicationInfo)
             map["installed_timestamp"] = File(packageInfo.applicationInfo.sourceDir).lastModified()
+            map["system_app"] = isSystemApp(packageManager, app.packageName)
             return map
+        }
+
+        private fun isSystemApp(packageManager: PackageManager, packageName: String): Boolean {
+            return try {
+                val appInfo = packageManager.getApplicationInfo(packageName, 0)
+                (appInfo.flags and ApplicationInfo.FLAG_SYSTEM) != 0 ||
+                        (appInfo.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0
+            } catch (e: PackageManager.NameNotFoundException) {
+                false
+            }
         }
 
 

--- a/lib/app_info.dart
+++ b/lib/app_info.dart
@@ -8,6 +8,7 @@ class AppInfo {
   int versionCode;
   BuiltWith builtWith;
   int installedTimestamp;
+  bool isSystemApp;
 
   AppInfo({
     required this.name,
@@ -17,6 +18,7 @@ class AppInfo {
     required this.versionCode,
     required this.builtWith,
     required this.installedTimestamp,
+    required this.isSystemApp,
   });
 
   factory AppInfo.create(dynamic data) {
@@ -28,6 +30,7 @@ class AppInfo {
       versionCode: data["version_code"] ?? 1,
       builtWith: parseBuiltWith(data["built_with"]),
       installedTimestamp: data["installed_timestamp"] ?? 0,
+      isSystemApp: data["system_app"] ?? false,
     );
   }
 

--- a/lib/installed_apps.dart
+++ b/lib/installed_apps.dart
@@ -10,6 +10,7 @@ class InstalledApps {
   /// [excludeSystemApps] specifies whether to exclude system apps from the list.
   /// [withIcon] specifies whether to include app icons in the list.
   /// [packageNamePrefix] is an optional parameter to filter apps with package names starting with a specific prefix.
+  /// [onlyAppsWithLaunchIntent] is an optional parameter to only include apps that have launch intent.
   ///
   /// Returns a list of [AppInfo] objects representing the installed apps.
   static Future<List<AppInfo>> getInstalledApps([

--- a/lib/installed_apps.dart
+++ b/lib/installed_apps.dart
@@ -16,7 +16,7 @@ class InstalledApps {
     bool excludeSystemApps = true,
     bool withIcon = false,
     String packageNamePrefix = "",
-    bool onlyAppsWithLaunchIntent = true,
+    bool onlyAppsWithLaunchIntent = false,
   ]) async {
     dynamic apps = await _channel.invokeMethod(
       "getInstalledApps",

--- a/lib/installed_apps.dart
+++ b/lib/installed_apps.dart
@@ -16,6 +16,7 @@ class InstalledApps {
     bool excludeSystemApps = true,
     bool withIcon = false,
     String packageNamePrefix = "",
+    bool onlyAppsWithLaunchIntent = true,
   ]) async {
     dynamic apps = await _channel.invokeMethod(
       "getInstalledApps",
@@ -23,6 +24,7 @@ class InstalledApps {
         "exclude_system_apps": excludeSystemApps,
         "with_icon": withIcon,
         "package_name_prefix": packageNamePrefix,
+        "only_apps_with_launch_intent": onlyAppsWithLaunchIntent,
       },
     );
     return AppInfo.parseList(apps);


### PR DESCRIPTION
### Problem:
Encountered an issue in the `DrawableUtil.kt` file where the `drawableToBitmap` function would throw the following error:

![image](https://github.com/user-attachments/assets/d9b1b385-9acc-48ab-8ffe-726a9a9895cb)

This error occurred when attempting to convert a drawable with invalid width and height values.

### Changes:
#### 1. Bug Fix in `drawableToBitmap` Function:
- Modified the `drawableToBitmap` function in `DrawableUtil.kt` to handle cases where the width and height of the drawable are less than or equal to 0.
- Added checks to ensure that the width and height are greater than 0 before proceeding with the bitmap conversion, preventing the `IllegalArgumentException` from being thrown.

#### 2. Enhancements to `AppInfo` and `getInstalledApps`:
- Added a new boolean property `isSystemApp` to the `AppInfo` model to indicate whether an application is a system app.
- Updated the `getInstalledApps` function to include a new parameter `only_apps_with_launch_intent`, allowing filtering of apps to only those that have a launch intent.

### Additional Details:
- This bug fix resolves the issue of crashes due to improper handling of drawable dimensions.
- The added properties and parameters provide more flexibility in handling app data, specifically filtering system apps and apps with launch intents.
- Ensured backward compatibility with the previous functionality of the plugin.
