### PR TITLE
Add support for excluding unlaunchable apps - as per pre-1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ possible.
 ``` dart
 List<AppInfo> apps = await InstalledApps.getInstalledApps(
 	bool excludeSystemApps,
+	bool excludeUnlaunchable,
 	bool withIcon,
 	String packageNamePrefix
 );

--- a/android/src/main/kotlin/com/sharmadhiraj/installed_apps/InstalledAppsPlugin.kt
+++ b/android/src/main/kotlin/com/sharmadhiraj/installed_apps/InstalledAppsPlugin.kt
@@ -131,7 +131,7 @@ class InstalledAppsPlugin() : MethodCallHandler, FlutterPlugin, ActivityAware {
             installedApps =
                 installedApps.filter { app -> !isSystemApp(packageManager, app.packageName) }
         if (excludeUnlaunchable)
-            installedApps = installedApps.filter { app -> !isLaunchable(packageManager, app.packageName) }
+            installedApps = installedApps.filter { app -> isLaunchable(packageManager, app.packageName) }
         if (packageNamePrefix.isNotEmpty())
             installedApps = installedApps.filter { app ->
                 app.packageName.startsWith(

--- a/android/src/main/kotlin/com/sharmadhiraj/installed_apps/InstalledAppsPlugin.kt
+++ b/android/src/main/kotlin/com/sharmadhiraj/installed_apps/InstalledAppsPlugin.kt
@@ -68,13 +68,13 @@ class InstalledAppsPlugin() : MethodCallHandler, FlutterPlugin, ActivityAware {
         }
         when (call.method) {
             "getInstalledApps" -> {
-                val includeSystemApps = call.argument("exclude_system_apps") ?: true
-                val includeSystemApps = call.argument("exclude_unlaunchable") ?: true
+                val excludeSystemApps = call.argument("exclude_system_apps") ?: true
+                val excludeLaunchableApps = call.argument("exclude_unlaunchable") ?: true
                 val withIcon = call.argument("with_icon") ?: false
                 val packageNamePrefix: String = call.argument("package_name_prefix") ?: ""
                 Thread {
                     val apps: List<Map<String, Any?>> =
-                        getInstalledApps(includeSystemApps, withIcon, packageNamePrefix)
+                        getInstalledApps(excludeSystemApps, excludeLaunchableApps, withIcon, packageNamePrefix)
                     result.success(apps)
                 }.start()
             }

--- a/example/lib/screens/app_list.dart
+++ b/example/lib/screens/app_list.dart
@@ -18,7 +18,7 @@ class AppListScreen extends StatelessWidget {
 
   Widget _buildBody() {
     return FutureBuilder<List<AppInfo>>(
-      future: InstalledApps.getInstalledApps(true, true),
+      future: InstalledApps.getInstalledApps(false, true, true),
       builder: (
         BuildContext buildContext,
         AsyncSnapshot<List<AppInfo>> snapshot,

--- a/example/lib/screens/home.dart
+++ b/example/lib/screens/home.dart
@@ -23,7 +23,7 @@ class HomeScreen extends StatelessWidget {
         _buildListItem(
           context,
           "Installed Apps",
-          "Get installed apps on device. With options to exclude system app, get app icon & matching package name prefix.",
+          "Get installed apps on device. With options to exclude system app, exclude unlaunchable apps, get app icon & matching package name prefix.",
           () => Navigator.push(
             context,
             MaterialPageRoute(builder: (context) => AppListScreen()),

--- a/lib/installed_apps.dart
+++ b/lib/installed_apps.dart
@@ -8,12 +8,14 @@ class InstalledApps {
   /// Retrieves a list of installed apps on the device.
   ///
   /// [excludeSystemApps] specifies whether to exclude system apps from the list.
+  /// [excludeUnlaunchable] specifies whether to exclude apps that cannot be launched
   /// [withIcon] specifies whether to include app icons in the list.
   /// [packageNamePrefix] is an optional parameter to filter apps with package names starting with a specific prefix.
   ///
   /// Returns a list of [AppInfo] objects representing the installed apps.
   static Future<List<AppInfo>> getInstalledApps([
     bool excludeSystemApps = true,
+    bool excludeUnlaunchable = true,
     bool withIcon = false,
     String packageNamePrefix = "",
   ]) async {
@@ -21,6 +23,7 @@ class InstalledApps {
       "getInstalledApps",
       {
         "exclude_system_apps": excludeSystemApps,
+        "exclude_unlaunchable": excludeUnlaunchable,
         "with_icon": withIcon,
         "package_name_prefix": packageNamePrefix,
       },


### PR DESCRIPTION
For #42 

Technically, this could have been achieved by reverting #27. But, as I don't know why that was changed, this introduces an additional new (required) method arg instead.

There's likely a neater backwards-compatible solution, but this at least addresses the issue should anyone need an emergency fix.