### PR TITLE
Handle missing packages and invalid icon sizes to avoid crashes

### DIFF
--- a/android/src/main/kotlin/com/sharmadhiraj/installed_apps/DrawableUtil.kt
+++ b/android/src/main/kotlin/com/sharmadhiraj/installed_apps/DrawableUtil.kt
@@ -9,11 +9,17 @@ import java.io.ByteArrayOutputStream
 class DrawableUtil {
 
     companion object {
+
         fun drawableToByteArray(drawable: Drawable): ByteArray {
-            val bitmap = drawableToBitmap(drawable)
-            ByteArrayOutputStream().use { stream ->
-                bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
-                return stream.toByteArray()
+            try {
+                val bitmap = drawableToBitmap(drawable)
+                ByteArrayOutputStream().use { stream ->
+                    bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                    return stream.toByteArray()
+                }
+            } catch (e: IllegalArgumentException) {
+                // Fallback: treat as no icon
+                return ByteArray(0)
             }
         }
 
@@ -21,11 +27,11 @@ class DrawableUtil {
             if (drawable is BitmapDrawable) {
                 return drawable.bitmap
             }
-            val bitmap = Bitmap.createBitmap(
-                drawable.intrinsicWidth,
-                drawable.intrinsicHeight,
-                Bitmap.Config.ARGB_8888
-            )
+
+            val width = if (drawable.intrinsicWidth > 0) drawable.intrinsicWidth else 1
+            val height = if (drawable.intrinsicHeight > 0) drawable.intrinsicHeight else 1
+
+            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
             val canvas = Canvas(bitmap)
             drawable.setBounds(0, 0, canvas.width, canvas.height)
             drawable.draw(canvas)

--- a/android/src/main/kotlin/com/sharmadhiraj/installed_apps/Util.kt
+++ b/android/src/main/kotlin/com/sharmadhiraj/installed_apps/Util.kt
@@ -22,11 +22,19 @@ class Util {
             map["icon"] =
                 if (withIcon) DrawableUtil.drawableToByteArray(app.loadIcon(packageManager))
                 else ByteArray(0)
-            val packageInfo = packageManager.getPackageInfo(app.packageName, 0)
-            map["version_name"] = packageInfo.versionName
-            map["version_code"] = getVersionCode(packageInfo)
-            map["built_with"] = platformType?.value ?: BuiltWithUtil.getPlatform(packageInfo.applicationInfo)
-            map["installed_timestamp"] = File(packageInfo.applicationInfo.sourceDir).lastModified()
+
+            val packageInfo = try {
+                packageManager.getPackageInfo(app.packageName, 0)
+            } catch (e: PackageManager.NameNotFoundException) {
+                null
+            }
+            if (packageInfo != null) {
+                map["version_name"] = packageInfo.versionName
+                map["version_code"] = getVersionCode(packageInfo)
+                map["built_with"] = platformType?.value ?: BuiltWithUtil.getPlatform(packageInfo.applicationInfo)
+                map["installed_timestamp"] = File(packageInfo.applicationInfo.sourceDir).lastModified()
+            }
+
             return map
         }
 


### PR DESCRIPTION
Description:
This PR fixes two crash scenarios:

Wrapped getPackageInfo() in a try/catch to avoid NameNotFoundException when the app can’t be found anymore. We now return safe default values instead of crashing.
crashlytics stacktrace:
```
Fatal Exception: android.content.pm.PackageManager$NameNotFoundException
com.whatsapp
android.app.ApplicationPackageManager.getPackageInfoAsUser (ApplicationPackageManager.java:361)
android.app.ApplicationPackageManager.getPackageInfo (ApplicationPackageManager.java:271)
com.sharmadhiraj.installed_apps.Util$Companion.convertAppToMap (Util.kt:25)
com.sharmadhiraj.installed_apps.InstalledAppsPlugin.getInstalledApps (InstalledAppsPlugin.kt:129)
com.sharmadhiraj.installed_apps.InstalledAppsPlugin.onMethodCall$lambda$0 (InstalledAppsPlugin.kt:65)
com.sharmadhiraj.installed_apps.InstalledAppsPlugin.$r8$lambda$Qqf10qNyOeNOEJ3hyYyfw8v2ORc
com.sharmadhiraj.installed_apps.InstalledAppsPlugin$$ExternalSyntheticLambda0.run (D8$$SyntheticClass)
java.lang.Thread.run (Thread.java:1119)
```

Added checks in DrawableUtil to handle drawables with zero width/height, and return a fallback or empty byte array instead of throwing IllegalArgumentException.
crashlytics stacktrace:
```
Fatal Exception: java.lang.IllegalArgumentException
width and height must be > 0
android.graphics.Bitmap.createBitmap (Bitmap.java:1113)
android.graphics.Bitmap.createBitmap (Bitmap.java:991)
com.sharmadhiraj.installed_apps.DrawableUtil$Companion.drawableToBitmap (DrawableUtil.kt:24)
com.sharmadhiraj.installed_apps.DrawableUtil$Companion.drawableToByteArray (DrawableUtil.kt:13)
com.sharmadhiraj.installed_apps.Util$Companion.convertAppToMap (Util.kt:23)
com.sharmadhiraj.installed_apps.InstalledAppsPlugin.getInstalledApps (InstalledAppsPlugin.kt:129)
com.sharmadhiraj.installed_apps.InstalledAppsPlugin.onMethodCall$lambda$0 (InstalledAppsPlugin.kt:65)
com.sharmadhiraj.installed_apps.InstalledAppsPlugin.$r8$lambda$Qqf10qNyOeNOEJ3hyYyfw8v2ORc
com.sharmadhiraj.installed_apps.InstalledAppsPlugin$$ExternalSyntheticLambda0.run (D8$$SyntheticClass)
java.lang.Thread.run (Thread.java:919)

```